### PR TITLE
Fix an breaking error in skipgram.py

### DIFF
--- a/skipgram.py
+++ b/skipgram.py
@@ -3,11 +3,14 @@ import pickle
 import os
 import numpy as np
 import argparse
+import json
+from tqdm import tqdm
 
 parser = argparse.ArgumentParser(description='The Embedded Topic Model')
 
 ### data and file related arguments
 parser.add_argument('--data_file', type=str, default='', help='a .txt file containing the corpus')
+parser.add_argument('--vocab_file', type=str, default='', help='a .json vocab file for the data post processing, in order to save embeddings only for the words needed')
 parser.add_argument('--emb_file', type=str, default='embeddings.txt', help='file to save the word embeddings')
 parser.add_argument('--dim_rho', type=int, default=300, help='dimensionality of the word embeddings')
 parser.add_argument('--min_count', type=int, default=2, help='minimum term frequency (to define the vocabulary)')
@@ -15,7 +18,7 @@ parser.add_argument('--sg', type=int, default=1, help='whether to use skip-gram'
 parser.add_argument('--workers', type=int, default=25, help='number of CPU cores')
 parser.add_argument('--negative_samples', type=int, default=10, help='number of negative samples')
 parser.add_argument('--window_size', type=int, default=4, help='window size to determine context')
-parser.add_argument('--iters', type=int, default=50, help='number of iterationst')
+parser.add_argument('--iters', type=int, default=5, help='number of iterationst')
 
 args = parser.parse_args()
 
@@ -31,14 +34,24 @@ class MySentences(object):
 
 # Gensim code to obtain the embeddings
 sentences = MySentences(args.data_file) # a memory-friendly iterator
+print('Model training begins')
 model = gensim.models.Word2Vec(sentences, min_count=args.min_count, sg=args.sg, size=args.dim_rho, 
-    iter=args.iters, workers=args.workers, negative=args.negative_samples, window=args.window_size)
-
+    iter=args.iters, workers=args.workers, negative=args.negative_samples, window=args.window_size, )
+print('Model trained')
+vocab = list(json.load(open(args.vocab_file)).keys())
 # Write the embeddings to a file
-with open(args.emb_file, 'w') as f:
-    for v in list(model.wv.vocab):
+model_vocab = list(model.wv.vocab)
+print(len(model_vocab))
+del sentences
+n = 0
+f = open(args.emb_file, 'w')
+for v in tqdm(model_vocab):
+    if v in vocab:
         vec = list(model.wv.__getitem__(v))
         f.write(v + ' ')
         vec_str = ['%.9f' % val for val in vec]
         vec_str = " ".join(vec_str)
         f.write(vec_str + '\n')
+        n += 1
+f.close()
+print('DONE! - saved embeddings for ' + str(n) + ' words.')

--- a/skipgram.py
+++ b/skipgram.py
@@ -25,8 +25,9 @@ class MySentences(object):
         self.filename = filename
  
     def __iter__(self):
-        for line in open(self.filename):
-            yield line.split()
+        with open(self.filename) as infile:
+            for line in infile:
+                yield line.split()
 
 # Gensim code to obtain the embeddings
 sentences = MySentences(args.data_file) # a memory-friendly iterator


### PR DESCRIPTION
The current sentence iterator doesn't close the file, which I _think_ (not sure) causes training to terminate prematurely. I was getting very low quality embeddings and short training times, but after this fix, embeddings become sensible again.